### PR TITLE
Use native `AddIncludeFile` method

### DIFF
--- a/cc/include/TableGen.h
+++ b/cc/include/TableGen.h
@@ -55,7 +55,7 @@ TableGenParserRef tableGenGet();
 void tableGenFree(TableGenParserRef tg_ref);
 TableGenBool tableGenAddSource(TableGenParserRef tg_ref, const char *source);
 void tableGenAddSourceFile(TableGenParserRef tg_ref, TableGenStringRef source);
-void tableGenAddIncludePath(TableGenParserRef tg_ref,
+void tableGenAddIncludeDirectory(TableGenParserRef tg_ref,
                             TableGenStringRef include);
 
 /// NOTE: TableGen currently relies on global state within a given parser

--- a/cc/include/TableGen.h
+++ b/cc/include/TableGen.h
@@ -26,10 +26,10 @@ extern "C" {
 #endif
 
 typedef enum {
-    TABLEGEN_DK_ERROR,
-    TABLEGEN_DK_WARNING,
-    TABLEGEN_DK_REMARK,
-    TABLEGEN_DK_NOTE,
+  TABLEGEN_DK_ERROR,
+  TABLEGEN_DK_WARNING,
+  TABLEGEN_DK_REMARK,
+  TABLEGEN_DK_NOTE,
 } TableGenDiagKind;
 
 typedef enum {
@@ -54,8 +54,7 @@ typedef void (*TableGenStringCallback)(TableGenStringRef, void *);
 TableGenParserRef tableGenGet();
 void tableGenFree(TableGenParserRef tg_ref);
 TableGenBool tableGenAddSource(TableGenParserRef tg_ref, const char *source);
-TableGenBool tableGenAddSourceFile(TableGenParserRef tg_ref,
-                                   TableGenStringRef source);
+void tableGenAddSourceFile(TableGenParserRef tg_ref, TableGenStringRef source);
 void tableGenAddIncludePath(TableGenParserRef tg_ref,
                             TableGenStringRef include);
 
@@ -162,14 +161,17 @@ TableGenBool tableGenIntInitGetValue(TableGenTypedInitRef ti, int64_t *integer);
 TableGenStringRef tableGenStringInitGetValue(TableGenTypedInitRef ti);
 char *tableGenStringInitGetValueNewString(TableGenTypedInitRef ti);
 TableGenRecordRef tableGenDefInitGetValue(TableGenTypedInitRef ti);
-void tableGenInitPrint(TableGenTypedInitRef ti,
-                         TableGenStringCallback callback, void *userData);
+void tableGenInitPrint(TableGenTypedInitRef ti, TableGenStringCallback callback,
+                       void *userData);
 void tableGenInitDump(TableGenTypedInitRef ti);
-TableGenBool tableGenPrintError(TableGenParserRef ref, TableGenSourceLocationRef loc_ref, TableGenDiagKind dk,
-                        TableGenStringRef message,
-                        TableGenStringCallback callback, void *userData);
+TableGenBool tableGenPrintError(TableGenParserRef ref,
+                                TableGenSourceLocationRef loc_ref,
+                                TableGenDiagKind dk, TableGenStringRef message,
+                                TableGenStringCallback callback,
+                                void *userData);
 TableGenSourceLocationRef tableGenSourceLocationNull();
-TableGenSourceLocationRef tableGenSourceLocationClone(TableGenSourceLocationRef loc_ref);
+TableGenSourceLocationRef
+tableGenSourceLocationClone(TableGenSourceLocationRef loc_ref);
 
 // Memory
 void tableGenSourceLocationFree(TableGenSourceLocationRef loc_ref);

--- a/cc/lib/TableGen.cpp
+++ b/cc/lib/TableGen.cpp
@@ -69,7 +69,7 @@ TableGenBool tableGenAddSource(TableGenParserRef tg_ref, const char *source) {
   return unwrap(tg_ref)->addSource(source);
 }
 
-void tableGenAddIncludePath(TableGenParserRef tg_ref,
+void tableGenAddIncludeDirectory(TableGenParserRef tg_ref,
                             TableGenStringRef include) {
   return unwrap(tg_ref)->addIncludeDirectory(
       StringRef(include.data, include.len));

--- a/cc/lib/TableGen.cpp
+++ b/cc/lib/TableGen.cpp
@@ -22,7 +22,7 @@ RecordKeeper *ctablegen::TableGenParser::parse() {
 
   for (const auto &file : files) {
     std::string full_path;
-    if (!sourceMgr.AddIncludeFile(std::string(file), SMLoc(), full_path)) {
+    if (!sourceMgr.AddIncludeFile(file, SMLoc(), full_path)) {
       return nullptr;
     }
   }

--- a/cc/lib/TableGen.cpp
+++ b/cc/lib/TableGen.cpp
@@ -62,7 +62,7 @@ TableGenParserRef tableGenGet() {
 void tableGenFree(TableGenParserRef tg_ref) { delete unwrap(tg_ref); }
 
 void tableGenAddSourceFile(TableGenParserRef tg_ref, TableGenStringRef source) {
-  return unwrap(tg_ref)->addSourceFile(StringRef(source.data, source.len));
+  unwrap(tg_ref)->addSourceFile(StringRef(source.data, source.len));
 }
 
 TableGenBool tableGenAddSource(TableGenParserRef tg_ref, const char *source) {

--- a/cc/lib/TableGen.cpp
+++ b/cc/lib/TableGen.cpp
@@ -12,7 +12,6 @@
 #include "TableGen.h"
 #include "Types.h"
 #include <cstring>
-#include <iostream>
 
 using ctablegen::RecordMap;
 using ctablegen::tableGenFromRecType;

--- a/cc/lib/TableGen.cpp
+++ b/cc/lib/TableGen.cpp
@@ -12,6 +12,7 @@
 #include "TableGen.h"
 #include "Types.h"
 #include <cstring>
+#include <iostream>
 
 using ctablegen::RecordMap;
 using ctablegen::tableGenFromRecType;
@@ -48,6 +49,7 @@ bool ctablegen::TableGenParser::addSourceFile(const StringRef source) {
       MemoryBuffer::getFile(source);
 
   if (std::error_code EC = FileOrErr.getError()) {
+    std::cerr << "tablegen error: " << EC << "\n";
     return false;
   }
 

--- a/cc/lib/TableGen.cpp
+++ b/cc/lib/TableGen.cpp
@@ -12,6 +12,7 @@
 #include "TableGen.h"
 #include "Types.h"
 #include <cstring>
+#include <string>
 
 using ctablegen::RecordMap;
 using ctablegen::tableGenFromRecType;
@@ -43,16 +44,9 @@ bool ctablegen::TableGenParser::addSource(const char *source) {
   return true;
 }
 
-bool ctablegen::TableGenParser::addSourceFile(const StringRef source) {
-  ErrorOr<std::unique_ptr<MemoryBuffer>> FileOrErr =
-      MemoryBuffer::getFile(source);
-
-  if (std::error_code EC = FileOrErr.getError()) {
-    return false;
-  }
-
-  sourceMgr.AddNewSourceBuffer(std::move(*FileOrErr), SMLoc());
-  return true;
+bool ctablegen::TableGenParser::addSourceFile(const StringRef path) {
+  std::string full_path = "";
+  return !sourceMgr.AddIncludeFile(std::string(path), SMLoc(), full_path);
 }
 
 TableGenParserRef tableGenGet() {

--- a/cc/lib/TableGen.cpp
+++ b/cc/lib/TableGen.cpp
@@ -12,7 +12,6 @@
 #include "TableGen.h"
 #include "Types.h"
 #include <cstring>
-#include <iostream>
 
 using ctablegen::RecordMap;
 using ctablegen::tableGenFromRecType;
@@ -49,7 +48,6 @@ bool ctablegen::TableGenParser::addSourceFile(const StringRef source) {
       MemoryBuffer::getFile(source);
 
   if (std::error_code EC = FileOrErr.getError()) {
-    std::cerr << "tablegen error: " << EC << "\n";
     return false;
   }
 

--- a/cc/lib/TableGen.cpp
+++ b/cc/lib/TableGen.cpp
@@ -12,7 +12,6 @@
 #include "TableGen.h"
 #include "Types.h"
 #include <cstring>
-#include <string>
 
 using ctablegen::RecordMap;
 using ctablegen::tableGenFromRecType;
@@ -44,9 +43,16 @@ bool ctablegen::TableGenParser::addSource(const char *source) {
   return true;
 }
 
-bool ctablegen::TableGenParser::addSourceFile(const StringRef path) {
-  std::string full_path = "";
-  return !sourceMgr.AddIncludeFile(std::string(path), SMLoc(), full_path);
+bool ctablegen::TableGenParser::addSourceFile(const StringRef source) {
+  ErrorOr<std::unique_ptr<MemoryBuffer>> FileOrErr =
+      MemoryBuffer::getFile(source);
+
+  if (std::error_code EC = FileOrErr.getError()) {
+    return false;
+  }
+
+  sourceMgr.AddNewSourceBuffer(std::move(*FileOrErr), SMLoc());
+  return true;
 }
 
 TableGenParserRef tableGenGet() {

--- a/cc/lib/TableGen.hpp
+++ b/cc/lib/TableGen.hpp
@@ -38,13 +38,15 @@ class TableGenParser {
 public:
   TableGenParser() {}
   bool addSource(const char *source);
-  bool addSourceFile(const StringRef source);
-  void addIncludePath(const StringRef include);
+  void addSourceFile(const StringRef source);
+  void addIncludeDirectory(const StringRef include);
   RecordKeeper *parse();
 
   SourceMgr sourceMgr;
+
 private:
   std::vector<std::string> includeDirs;
+  std::vector<std::string> files;
 };
 
 // Utility
@@ -60,7 +62,7 @@ public:
         opaqueData(opaqueData), pos(0u) {}
 
   void write_impl(const char *ptr, size_t size) override {
-    TableGenStringRef string = TableGenStringRef { .data = ptr, .len = size };
+    TableGenStringRef string = TableGenStringRef{.data = ptr, .len = size};
     callback(string, opaqueData);
     pos += size;
   }
@@ -75,7 +77,8 @@ private:
 
 } // namespace ctablegen
 
-DEFINE_SIMPLE_CONVERSION_FUNCTIONS(ctablegen::TableGenParser, TableGenParserRef);
+DEFINE_SIMPLE_CONVERSION_FUNCTIONS(ctablegen::TableGenParser,
+                                   TableGenParserRef);
 DEFINE_SIMPLE_CONVERSION_FUNCTIONS(RecordKeeper, TableGenRecordKeeperRef);
 
 DEFINE_SIMPLE_CONVERSION_FUNCTIONS(ctablegen::RecordMap, TableGenRecordMapRef);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -71,6 +71,24 @@
 //! # }
 //! ```
 //!
+//! You can also pass an included file's path directly.
+//!
+//! ```rust
+//! use tblgen_alt::{TableGenParser, RecordKeeper};
+//! use std::path::Path;
+//!
+//! # fn main() -> Result<(), Box<dyn std::error::Error>> {
+//! let keeper: RecordKeeper = TableGenParser::new()
+//!     .add_source_file("mlir/IR/OpBase.td")?
+//!     .add_include_path(&format!("{}/include", std::env::var("TABLEGEN_190_PREFIX")?))
+//!     .parse()?;
+//! let i32_def = keeper.def("I32").expect("has I32 def");
+//! assert!(i32_def.subclass_of("I"));
+//! assert_eq!(i32_def.int_value("bitwidth"), Ok(32));
+//! # Ok(())
+//! # }
+//! ```
+//!
 //! # API Stability
 //!
 //! LLVM does not provide a stable C API for TableGen, and the C API provided by

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -79,7 +79,7 @@
 //!
 //! # fn main() -> Result<(), Box<dyn std::error::Error>> {
 //! let keeper: RecordKeeper = TableGenParser::new()
-//!     .add_source_file("mlir/IR/OpBase.td")?
+//!     .add_source_file("mlir/IR/OpBase.td")
 //!     .add_include_path(&format!("{}/include", std::env::var("TABLEGEN_190_PREFIX")?))
 //!     .parse()?;
 //! let i32_def = keeper.def("I32").expect("has I32 def");
@@ -168,12 +168,9 @@ impl<'s> TableGenParser<'s> {
     }
 
     /// Reads TableGen source code from the file at the given path.
-    pub fn add_source_file(self, source: &str) -> Result<Self, Error> {
-        if unsafe { tableGenAddSourceFile(self.raw, StringRef::from(source).to_raw()) > 0 } {
-            Ok(self)
-        } else {
-            Err(TableGenError::InvalidSource.into())
-        }
+    pub fn add_source_file(self, source: &str) -> Self {
+        unsafe { tableGenAddSourceFile(self.raw, StringRef::from(source).to_raw()) }
+        self
     }
 
     /// Adds the given TableGen source string.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -62,7 +62,7 @@
 //! # fn main() -> Result<(), Box<dyn std::error::Error>> {
 //! let keeper: RecordKeeper = TableGenParser::new()
 //!     .add_source(r#"include "mlir/IR/OpBase.td""#)?
-//!     .add_include_path(&format!("{}/include", std::env::var("TABLEGEN_190_PREFIX")?))
+//!     .add_include_directory(&format!("{}/include", std::env::var("TABLEGEN_190_PREFIX")?))
 //!     .parse()?;
 //! let i32_def = keeper.def("I32").expect("has I32 def");
 //! assert!(i32_def.subclass_of("I"));
@@ -80,7 +80,7 @@
 //! # fn main() -> Result<(), Box<dyn std::error::Error>> {
 //! let keeper: RecordKeeper = TableGenParser::new()
 //!     .add_source_file("mlir/IR/OpBase.td")
-//!     .add_include_path(&format!("{}/include", std::env::var("TABLEGEN_190_PREFIX")?))
+//!     .add_include_directory(&format!("{}/include", std::env::var("TABLEGEN_190_PREFIX")?))
 //!     .parse()?;
 //! let i32_def = keeper.def("I32").expect("has I32 def");
 //! assert!(i32_def.subclass_of("I"));
@@ -126,7 +126,7 @@ pub use record::RecordValue;
 pub use record_keeper::RecordKeeper;
 
 use raw::{
-    tableGenAddIncludePath, tableGenAddSource, tableGenAddSourceFile, tableGenFree, tableGenGet,
+    tableGenAddIncludeDirectory, tableGenAddSource, tableGenAddSourceFile, tableGenFree, tableGenGet,
     tableGenParse, TableGenParserRef,
 };
 use string_ref::StringRef;
@@ -162,8 +162,8 @@ impl<'s> TableGenParser<'s> {
     }
 
     /// Adds the given path to the list of included directories.
-    pub fn add_include_path(self, include: &str) -> Self {
-        unsafe { tableGenAddIncludePath(self.raw, StringRef::from(include).to_raw()) }
+    pub fn add_include_directory(self, include: &str) -> Self {
+        unsafe { tableGenAddIncludeDirectory(self.raw, StringRef::from(include).to_raw()) }
         self
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -71,7 +71,7 @@
 //! # }
 //! ```
 //!
-//! You can also pass an included file's path directly.
+//! You can also pass an included filename directly.
 //!
 //! ```rust
 //! use tblgen_alt::{TableGenParser, RecordKeeper};
@@ -126,8 +126,8 @@ pub use record::RecordValue;
 pub use record_keeper::RecordKeeper;
 
 use raw::{
-    tableGenAddIncludeDirectory, tableGenAddSource, tableGenAddSourceFile, tableGenFree, tableGenGet,
-    tableGenParse, TableGenParserRef,
+    tableGenAddIncludeDirectory, tableGenAddSource, tableGenAddSourceFile, tableGenFree,
+    tableGenGet, tableGenParse, TableGenParserRef,
 };
 use string_ref::StringRef;
 

--- a/tools/setup.sh
+++ b/tools/setup.sh
@@ -11,5 +11,5 @@ llvm_prefix=$(brew --prefix llvm@$llvm_version)
 
 echo TABLEGEN_190_PREFIX=$llvm_prefix >>$GITHUB_ENV
 echo PATH=$llvm_prefix/bin:$PATH >>$GITHUB_ENV
-echo LIBRARY_PATH=$(brew --prefix)/lib:$LIBRARY_PATH >>$GITHUB_ENV
-echo LD_LIBRARY_PATH=$(brew --prefix)/lib:$LD_LIBRARY_PATH >>$GITHUB_ENV
+echo LIBRARY_PATH=$llvm_prefix/lib:$LIBRARY_PATH >>$GITHUB_ENV
+echo LD_LIBRARY_PATH=$llvm_prefix/lib:$LD_LIBRARY_PATH >>$GITHUB_ENV

--- a/tools/setup.sh
+++ b/tools/setup.sh
@@ -11,5 +11,5 @@ llvm_prefix=$(brew --prefix llvm@$llvm_version)
 
 echo TABLEGEN_190_PREFIX=$llvm_prefix >>$GITHUB_ENV
 echo PATH=$llvm_prefix/bin:$PATH >>$GITHUB_ENV
-echo LIBRARY_PATH=$llvm_prefix/lib:$LIBRARY_PATH >>$GITHUB_ENV
-echo LD_LIBRARY_PATH=$llvm_prefix/lib:$LD_LIBRARY_PATH >>$GITHUB_ENV
+echo LIBRARY_PATH=$(brew --prefix)/lib:$LIBRARY_PATH >>$GITHUB_ENV
+echo LD_LIBRARY_PATH=$(brew --prefix)/lib:$LD_LIBRARY_PATH >>$GITHUB_ENV


### PR DESCRIPTION
This PR changes the `add_source_file` method in Rust to use `AddIncludeFile` in C++ which resolves given file paths from include directories.

This PR depends on #19.

# References

- https://github.com/mlir-rs/melior/pull/654
- https://llvm.org/doxygen/classllvm_1_1SourceMgr.html